### PR TITLE
Correcting hip package dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ rocm_create_package(
     DESCRIPTION "MIOpen and Tensile integration library"
     MAINTAINER "MIOpenTensile Support <miopen-lib.support@amd.com>"
     LDCONFIG
-    DEPENDS hip-hcc
+    DEPENDS hip-rocclr hip-base
 )
 
 rocm_install_targets(


### PR DESCRIPTION
Hip package names have been changed because of the new rocm packaging standards. Hence the hip-hcc dependency needs to be changed to hip-rocclr hip-base

Checked with 4.3, 4.4 & 4.5 for installation.